### PR TITLE
Obey the MINI_BREAKPAD_SERVER_ROOT variable

### DIFF
--- a/src/app.coffee
+++ b/src/app.coffee
@@ -87,7 +87,7 @@ app.get '/#{root}fetch', (req, res, next) ->
     console.log "Queueing symbols from #{rel.name}..."
     webhook.downloadAssets {'repository': {'full_name': req.query.project}, 'release': rel}
     
-  github.getReleases {}, (err, rels)-> 
+  github.getReleases {}, (err, rels)->
     return next err if err?
     return next "Error fetching releases from #{req.query.project}" if !rels?
     processRel rel for rel in rels

--- a/views/login.jade
+++ b/views/login.jade
@@ -1,7 +1,7 @@
 extends layout
 
 block content
-  form(action='/login', method='post')
+  form(action='login', method='post')
     div
       label username:
       input(type='text', name='username')


### PR DESCRIPTION
This makes Caliper obey the environment variable `MINI_BREAKPAD_SERVER_ROOT` for all paths, so it can run from a prefix under the server root.
Also fixes a whitespace issue.
